### PR TITLE
feat: replace Windows command-line scripts

### DIFF
--- a/pdf_compressor.py
+++ b/pdf_compressor.py
@@ -75,7 +75,7 @@ def compress(input_file_path, output_file_path, power=0):
 
 
 def get_ghostscript_path():
-    gs_names = ["gs", "gswin32", "gswin64"]
+    gs_names = ["gs", "gswin32c", "gswin64c"]
     for name in gs_names:
         if shutil.which(name):
             return shutil.which(name)


### PR DESCRIPTION
**Ghostscript Version:** Ghostscript 10.05.0 for Windows (64 bit)  
**Windows Version:** Windows 11 23H2 22631.5039  

When running commands with `gswin32` and `gswin64` on Windows, they open their own window, which disappears after execution. It is recommended to use `gswin32c` and `gswin64c` instead to resolve this issue.  

**Official Description:**  

> The name of the Ghostscript command line executable on MS Windows is gswin32c/gswin64c so use this instead of the plain ‘gs’ in the quickstart examples.  

> There is also an older version for MS Windows called just gswin32 that provides its own window for the interactive PostScript prompt. The executable gswin32c/gswin64c is usually the better option since it uses the native command prompt window.